### PR TITLE
Adding Postgres Autoconfiguration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,4 +41,4 @@ COPY . /home/app
 RUN mvn -B -Pproduction -DskipTests -f /home/app/pom.xml clean package
 
 RUN ["chmod", "+x", "/home/app/startup.sh"]
-ENTRYPOINT ["startup.sh","/home/app/target/example-1.1.0.jar"]
+ENTRYPOINT ["/home/app/startup.sh","/home/app/target/example-1.1.0.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,5 @@ COPY . /home/app
 
 RUN mvn -B -Pproduction -DskipTests -f /home/app/pom.xml clean package
 
-ENTRYPOINT ["java","-jar","/home/app/target/example-1.1.0.jar"]
+RUN ["chmod", "+x", "/home/app/startup.sh"]
+ENTRYPOINT ["startup.sh","/home/app/target/example-1.1.0.jar"]

--- a/startup.sh
+++ b/startup.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+export JDBC_DATABASE_PASSWORD=$(echo "$DATABASE_URL" | cut --delimiter=: -f3 | cut --delimiter=\@ -f1)
+
+export JDBC_DATABASE_URL=jdbc:postgresql://$(echo "$DATABASE_URL" | cut --delimiter=\@ -f2)
+
+export JDBC_DATABASE_USERNAME=postgres
+
+java -jar $1


### PR DESCRIPTION
In this PR, we rewrite the way that the Dokku environment variables `JDBC_DATABASE_USERNAME`, `JDBC_DATABASE_PASSWORD`, and `JDBC_DATABASE_URL` are handled. Previously, students would need to manually deconstruct the url provided from linking the database and fill in these fields. This has been moved to a script that runs just before the application starts in the Docker container, setting the 3 variables based on `DATABASE_URL` with some bash scripting. The new process for creating a Postgres database is to run `dokku postgres:create <db-name>` followed by `dokku postgres:link <db-name> <appname>`.
A dokku instance will be deployed shortly. Sister PR of [team01](https://github.com/ucsb-cs156-s25/STARTER-team01/pull/17).

Deployed to https://jpa03-postgres.dokku-00.cs.ucsb.edu/ with no manually set postgres variables.
